### PR TITLE
Updated script without invalid links. File MUST be manually downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Photoshop-CC2022-Linux
 
-## Links are down, that's intended until I find a more legitimate solution for everyone.
+### Updated fork. **MUST DOWNLOAD** manually the file AdobePhotoshop2021.tar.xz
+
+### Make sure you place AdobePhotoshop2021.tar.xz in the same directory as this script
+
+#### **Refer to this [GitHub comment](https://github.com/LinSoftWin/Photoshop-CC2022-Linux/pull/128#issuecomment-2043562369) for a blazing-fast alternative download source**
+
+-  **SHA256 SUM for checking file authenticity:** 8321b969161f2d2ad736067320d493c5b6ae579eaab9400cd1fda6871af2c033
+
 
 ## Important
 
@@ -27,6 +34,8 @@ If you use something from my repo in your project please credit me
 *File download is about 2GB*
 
 ## Requirements
+
+**Tested CC2021 on openSUSE Tumbleweed** using Wine-9.6, no problems so far
 - wine >=6.1 (Avoid 6.20 to 6.22 **DON'T USE STAGING**) 
 
 (Wine 8.0+ are causing an issue with the windows version see workaround [here](https://github.com/MiMillieuh/Photoshop-CC2022-Linux/issues/94#issuecomment-1426776219))

--- a/scripts/photoshop2021install.sh
+++ b/scripts/photoshop2021install.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Seems that mimifile is a placeholder for the progress bar
+# This script is a modified version of the original script by LinSoftWin
 
 mkdir $1/Adobe-Photoshop
 
@@ -13,7 +15,7 @@ echo "10" >> $1/progress.mimifile
 
 WINEPREFIX=$1/Adobe-Photoshop ./winetricks win10
 
-curl -L -P0 "https://lulucloud.mywire.org/FileHosting/GithubProjects/allredist.tar.xz" > allredist.tar.xz
+curl -L "https://drive.google.com/uc?export=download&id=1qcmyHzWerZ39OhW0y4VQ-hOy7639bJPO" > allredist.tar.xz
 mkdir allredist
 
 rm -rf $1/progress.mimifile
@@ -27,27 +29,27 @@ rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "25" >> $1/progress.mimifile
 
-curl -L -P0 "https://lulucloud.mywire.org/FileHosting/GithubProjects/AdobePhotoshop2021.tar.xz" > AdobePhotoshop2021.tar.xz
+# Removed download link on purpose
+# Make sure you have the file AdobePhotoshop2021.tar.xz in the same directory as this script
 
-rm -rf $1/progress.mimifile
+# Refer to this github comment for a blazing-fast alternative download source:
+# https://github.com/LinSoftWin/Photoshop-CC2022-Linux/pull/128#issuecomment-2043562369
+
 touch $1/progress.mimifile
 echo "50" >> $1/progress.mimifile
 
 tar -xf AdobePhotoshop2021.tar.xz
 rm -rf AdobePhotoshop2021.tar.xz
 
-
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "70" >> $1/progress.mimifile
-
 
 WINEPREFIX=$1/Adobe-Photoshop ./winetricks fontsmooth=rgb gdiplus msxml3 msxml6 atmlib corefonts dxvk win10 vkd3d
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
 echo "80" >> $1/progress.mimifile
-
 
 WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2010/vcredist_x64.exe /q /norestart
 WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2010/vcredist_x86.exe /q /norestart
@@ -60,7 +62,6 @@ WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2013/vcredist_x64.exe /insta
 
 WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x64.exe /install /quiet /norestart
 WINEPREFIX=$1/Adobe-Photoshop wine allredist/redist/2019/VC_redist.x86.exe /install /quiet /norestart
-
 
 rm -rf $1/progress.mimifile
 touch $1/progress.mimifile
@@ -78,29 +79,30 @@ echo 'RESOURCES_PATH="$SCR_PATH/resources"' >> $1/Adobe-Photoshop/drive_c/launch
 echo 'WINE_PREFIX="$SCR_PATH/prefix"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
 echo 'FILE_PATH=$(winepath -w "$1")' >> $1/Adobe-Photoshop/drive_c/launcher.sh
 echo 'export WINEPREFIX="'$1'/Adobe-Photoshop"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
-echo 'WINEPREFIX='$1'/Adobe-Photoshop DXVK_LOG_PATH='$1'/Adobe-Photoshop DXVK_STATE_CACHE_PATH='$1'/Adobe-Photoshop wine64 ' $1'/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021/photoshop.exe "$FILE_PATH"' >> $1/Adobe-Photoshop/drive_c/launcher.sh
+echo 'WINEPREFIX='$1'/Adobe-Photoshop DXVK_LOG_PATH='$1'/Adobe-Photoshop DXVK_STATE_CACHE_PATH='$1'/Adobe-Photoshop wine64 ' $1'/Adobe-Photoshop/drive_c/Program\ Files/Adobe/Adobe\ Photoshop\ 2021/photoshop.exe $FILE_PATH' >> $1/Adobe-Photoshop/drive_c/launcher.sh
 
 chmod +x $1/Adobe-Photoshop/drive_c/launcher.sh
 
 WINEPREFIX=$1/Adobe-Photoshop winecfg -v win10
 
-
 mv allredist/photoshop.png ~/.local/share/icons/photoshop.png
 
+# Included mimetypes for default handlers
+# Updated name, comment and categories
 
 touch ~/.local/share/applications/photoshop.desktop
 echo '[Desktop Entry]' >> ~/.local/share/applications/photoshop.desktop
-echo 'Name=Photoshop CC 2021' >> ~/.local/share/applications/photoshop.desktop
+echo 'Name=Adobe Photoshop CC 2021' >> ~/.local/share/applications/photoshop.desktop
 echo 'Exec=bash -c "'$1'/Adobe-Photoshop/drive_c/launcher.sh %F"' >> ~/.local/share/applications/photoshop.desktop
 echo 'Type=Application' >> ~/.local/share/applications/photoshop.desktop
-echo 'Comment=Photoshop CC 2021 (Wine)' >> ~/.local/share/applications/photoshop.desktop
-echo 'Categories=Graphics;' >> ~/.local/share/applications/photoshop.desktop
-echo 'Icon=photoshop' >> ~/.local/share/applications/photoshop.desktop
+echo 'Comment=The industry-standard photo editing software (Wine)' >> ~/.local/share/applications/photoshop.desktop
+echo 'Categories=Graphics;Photography;' >> ~/.local/share/applications/photoshop.desktop
+echo 'Icon=$HOME/.local/share/icons/photoshop.png' >> ~/.local/share/applications/photoshop.desktop
+echo 'MimeType=image/psd;image/x-psd;' >> ~/.local/share/applications/photoshop.desktop
 echo 'StartupWMClass=photoshop.exe' >> ~/.local/share/applications/photoshop.desktop
 
 rm -rf allredist
 rm -rf winetricks
 
-rm -rf $1/progress.mimifile
-touch $1/progress.mimifile
 echo "100" >> $1/progress.mimifile
+rm -rf $1/progress.mimifile


### PR DESCRIPTION
File AdobePhotoshop2021 must be manually downloaded, otherwise won't work
**Refer to this [GitHub comment](https://github.com/LinSoftWin/Photoshop-CC2022-Linux/pull/128#issuecomment-2043562369) for a blazing-fast alternative download source**
- Updated photoshop2021script.sh
- Refreshed photoshop.desktop file